### PR TITLE
adding aarch64 platform to picodrive compilation arguments

### DIFF
--- a/core.json
+++ b/core.json
@@ -1182,7 +1182,7 @@
     "output": "picodrive_libretro.so",
     "make": {
       "file": "Makefile.libretro",
-      "args": "",
+      "args": "platform=aarch64",
       "target": ""
     },
     "symbols": 0

--- a/core.json
+++ b/core.json
@@ -1185,7 +1185,12 @@
       "args": "platform=aarch64",
       "target": ""
     },
-    "symbols": 0
+    "symbols": 0,
+    "commands": {
+      "pre-make": [
+        "git submodule update --init --recursive"
+      ]
+    }
   },
   "pocketcdg": {
     "source": "https://github.com/libretro/libretro-pocketcdg",


### PR DESCRIPTION
I did some research into picodrive 32x slowness and found that the banana and pixie cores weren't compiled with SH2 dynarec enabled. based on my research I think adding this platform argument will add support for the dynarec. You can check out my research notes here if you want: https://github.com/plaidman/cube-xx/wiki/zz.-picodrive-notes, most importantly the last paragraph.

Unfortunately I don't have the toolchain set up to test if this fix works or not. If someone wants to compile and test, the relevant option is in core options -> performance -> dynamic recompilers. In the pixie build the option is not present at all.