### PR TITLE
Update Build to skip already built cores

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -289,10 +289,10 @@ for NAME in $CORES; do
 	printf "Remote hash: %s\n" "$REMOTE_HASH"
 	printf "Cached hash: %s\n" "$CACHED_HASH"
 
-    if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$BUILD_DIR/$OUTPUT.zip" ]; then
-        printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
-        continue
-    fi
+	if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$BUILD_DIR/$OUTPUT.zip" ]; then
+		printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
+		continue
+	fi
 
 
 	if [ "$PURGE" -eq 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -289,10 +289,10 @@ for NAME in $CORES; do
 	printf "Remote hash: %s\n" "$REMOTE_HASH"
 	printf "Cached hash: %s\n" "$CACHED_HASH"
 
-	if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$BUILD_DIR/$OUTPUT.zip" ]; then
-    	printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
-    	continue
-	fi
+    if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$BUILD_DIR/$OUTPUT.zip" ]; then
+        printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
+        continue
+    fi
 
 
 	if [ "$PURGE" -eq 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -289,10 +289,11 @@ for NAME in $CORES; do
 	printf "Remote hash: %s\n" "$REMOTE_HASH"
 	printf "Cached hash: %s\n" "$CACHED_HASH"
 
-	if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$OUTPUT" ]; then
-		printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
-		continue
+	if [ "$CACHED_HASH" = "$REMOTE_HASH" ] && [ "$PURGE" -eq 0 ] && [ -f "$BUILD_DIR/$OUTPUT.zip" ]; then
+    	printf "Core '%s' is up to date (hash: %s). Skipping build.\n" "$NAME" "$REMOTE_HASH"
+    	continue
 	fi
+
 
 	if [ "$PURGE" -eq 1 ]; then
 		printf "Purging core '%s' directory\n" "$DIR"

--- a/build.sh
+++ b/build.sh
@@ -294,7 +294,6 @@ for NAME in $CORES; do
 		continue
 	fi
 
-
 	if [ "$PURGE" -eq 1 ]; then
 		printf "Purging core '%s' directory\n" "$DIR"
 		rm -rf "$CORE_DIR"

--- a/build.sh
+++ b/build.sh
@@ -418,7 +418,7 @@ fi
 	PV_PID=$!
 	trap 'kill $PV_PID 2>/dev/null' EXIT
 
-	MAKE_CMD="make V-1 -j$(nproc)"
+	MAKE_CMD="make V=1 -j$(nproc)"
 	[ -n "$MAKE_FILE" ] && MAKE_CMD="$MAKE_CMD -f $MAKE_FILE"
 	[ -n "$MAKE_ARGS" ] && MAKE_CMD="$MAKE_CMD $MAKE_ARGS"
 	[ -n "$MAKE_TARGET" ] && MAKE_CMD="$MAKE_CMD $MAKE_TARGET"


### PR DESCRIPTION
Output file check works properly now, it was looking for the so files but they get moved/zipped so it would always build even when nothing changed.