### PR TITLE
Working SegaCD

### DIFF
--- a/core.json
+++ b/core.json
@@ -1282,6 +1282,7 @@
   },
   "picodrive": {
     "source": "https://github.com/irixxxx/picodrive",
+    "branch": "7cbcd41",
     "directory": "picodrive",
     "output": "picodrive_libretro.so",
     "make": {


### PR DESCRIPTION
Pins picodrive to https://github.com/irixxxx/picodrive/commit/7cbcd41